### PR TITLE
Add extension of Progression

### DIFF
--- a/Progression/Extensions/PeriodExtension.cs
+++ b/Progression/Extensions/PeriodExtension.cs
@@ -50,5 +50,43 @@ namespace YggdrAshill.Ragnarok.Progression
 
             return period;
         }
+
+        /// <summary>
+        /// Initializes <see cref="IPeriod"/>.
+        /// </summary>
+        /// <param name="period">
+        /// <see cref="IPeriod"/> to initialize.
+        /// </param>
+        /// <returns>
+        /// <see cref="IDisposable"/> to finalize period.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="period"/> is null.
+        /// </exception>
+        public static IDisposable Initialize(this IPeriod period)
+        {
+            if (period == null)
+            {
+                throw new ArgumentNullException(nameof(period));
+            }
+
+            period.Originate();
+
+            return new DisposeToFinalize(period);
+        }
+        private sealed class DisposeToFinalize : IDisposable
+        {
+            private readonly IPeriod period;
+
+            internal DisposeToFinalize(IPeriod period)
+            {
+                this.period = period;
+            }
+
+            public void Dispose()
+            {
+                period.Terminate();
+            }
+        }
     }
 }

--- a/YggdrAshill.Ragnarok.Specification/Progression/PeriodExtensionSpecification.cs
+++ b/YggdrAshill.Ragnarok.Specification/Progression/PeriodExtensionSpecification.cs
@@ -32,6 +32,26 @@ namespace YggdrAshill.Ragnarok.Specification
         }
 
         [Test]
+        public void ShouldInitializeThenFinalize()
+        {
+            using (period.Initialize())
+            {
+                Assert.IsTrue(period.Originated);
+            }
+
+            Assert.IsTrue(period.Terminated);
+        }
+
+        [Test]
+        public void CannotInitializeWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var disposable = default(IPeriod).Initialize();
+            });
+        }
+
+        [Test]
         public void CannotConvertWithNull()
         {
             Assert.Throws<ArgumentNullException>(() =>


### PR DESCRIPTION
## Summary

The extension make `IPeriod` and `IProcess` to initialize itselt and return `IDisposable` to finalize it.
The specifications of the extension were also written.

## Done

Same as title above.

## Undone

Nothing.

## Influence

Developers can now write in order `IPeriod` to initialize and finalize like:

```
using (period.Initialize())
{
    // do something...
}
```

or `IProcess` to initialize and finalize like:
```
using (process.Initialize())
{
    process.Execute();
}
```

## Concerns

Nothing because this pull request was created by repository owner.

## Additional context (Optional)

Nothing because this pull request was created by repository owner.
